### PR TITLE
Fix CI tests by temporarily downgrading to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
 
     test:
         name: Test
-        runs-on: ubuntu-latest
+        # Temporarily use Ubuntu 22.04, until upstream Floating UI support 24.04 (https://github.com/floating-ui/floating-ui/pull/3214).
+        runs-on: ubuntu-22.04
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Temporary fix until https://github.com/floating-ui/floating-ui/pull/3214 is merged.