### PR TITLE
ci: use latest Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
 
     test:
         name: Test
-        # Temporarily use Ubuntu 22.04, until upstream Floating UI support 24.04 (https://github.com/floating-ui/floating-ui/pull/3214).
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Revert #109, because https://github.com/floating-ui/floating-ui/pull/3214 was merged.