### PR TITLE
fix: use stable Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Set up Rust toolchain
-              run: rustup toolchain install nightly --no-self-update --profile default --target wasm32-unknown-unknown
+              run: rustup toolchain install stable --no-self-update --profile default --target wasm32-unknown-unknown
 
             - name: Set up Rust cache
               uses: swatinem/rust-cache@v2
@@ -41,6 +41,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            # TODO: Investigate why tests fail on stable toolchain.
             - name: Set up Rust toolchain
               run: rustup toolchain install nightly --no-self-update --profile default --target wasm32-unknown-unknown
 
@@ -66,8 +67,9 @@ jobs:
               with:
                   version: 'latest'
 
+            # TODO: See comment above about nightly toolchain.
             - name: Test
-              run: cargo test --all-features
+              run: cargo +nightly test --all-features
 
             - name: Upload visual snapshot diffs
               uses: actions/upload-artifact@v4

--- a/packages/core/src/compute_position.rs
+++ b/packages/core/src/compute_position.rs
@@ -86,40 +86,42 @@ pub fn compute_position<Element: Clone, Window: Clone>(
             middleware_data.set(middleware.name(), new_data);
         }
 
-        if let Some(reset) = reset
-            && reset_count <= 50
-        {
-            reset_count += 1;
+        if let Some(reset) = reset {
+            if reset_count <= 50 {
+                reset_count += 1;
 
-            match reset {
-                Reset::True => {}
-                Reset::Value(value) => {
-                    if let Some(reset_placement) = value.placement {
-                        stateful_placement = reset_placement;
-                    }
-
-                    if let Some(reset_rects) = value.rects {
-                        rects = match reset_rects {
-                            ResetRects::True => platform.get_element_rects(GetElementRectsArgs {
-                                reference: reference.clone(),
-                                floating,
-                                strategy,
-                            }),
-                            ResetRects::Value(element_rects) => element_rects,
+                match reset {
+                    Reset::True => {}
+                    Reset::Value(value) => {
+                        if let Some(reset_placement) = value.placement {
+                            stateful_placement = reset_placement;
                         }
+
+                        if let Some(reset_rects) = value.rects {
+                            rects = match reset_rects {
+                                ResetRects::True => {
+                                    platform.get_element_rects(GetElementRectsArgs {
+                                        reference: reference.clone(),
+                                        floating,
+                                        strategy,
+                                    })
+                                }
+                                ResetRects::Value(element_rects) => element_rects,
+                            }
+                        }
+
+                        let Coords {
+                            x: next_x,
+                            y: next_y,
+                        } = compute_coords_from_placement(&rects, stateful_placement, rtl);
+                        x = next_x;
+                        y = next_y;
                     }
-
-                    let Coords {
-                        x: next_x,
-                        y: next_y,
-                    } = compute_coords_from_placement(&rects, stateful_placement, rtl);
-                    x = next_x;
-                    y = next_y;
                 }
-            }
 
-            i = 0;
-            continue;
+                i = 0;
+                continue;
+            }
         }
 
         i += 1;

--- a/packages/core/src/middleware/inline.rs
+++ b/packages/core/src/middleware/inline.rs
@@ -186,21 +186,21 @@ impl<Element: Clone + PartialEq + 'static, Window: Clone + PartialEq + 'static>
 
         let get_bounding_client_rect = move || {
             // There are two rects and they are disjoined.
-            if client_rects.len() == 2
-                && client_rects[0].left > client_rects[1].right
-                && let Some(x) = options.x
-                && let Some(y) = options.y
-            {
-                return client_rects
-                    .clone()
-                    .into_iter()
-                    .find(|rect| {
-                        x > rect.left - padding_object.left
-                            && x < rect.right + padding_object.right
-                            && y > rect.top - padding_object.top
-                            && rect.y < rect.bottom + padding_object.bottom
-                    })
-                    .unwrap_or(fallback.clone());
+            if client_rects.len() == 2 && client_rects[0].left > client_rects[1].right {
+                if let Some(x) = options.x {
+                    if let Some(y) = options.y {
+                        return client_rects
+                            .clone()
+                            .into_iter()
+                            .find(|rect| {
+                                x > rect.left - padding_object.left
+                                    && x < rect.right + padding_object.right
+                                    && y > rect.top - padding_object.top
+                                    && rect.y < rect.bottom + padding_object.bottom
+                            })
+                            .unwrap_or(fallback.clone());
+                    }
+                }
             }
 
             // There are 2 or more connected rects.

--- a/packages/core/src/middleware/offset.rs
+++ b/packages/core/src/middleware/offset.rs
@@ -41,13 +41,13 @@ fn convert_value_to_coords<Element: Clone, Window: Clone>(
         ),
     };
 
-    if let Some(alignment) = alignment
-        && let Some(alignment_axis) = alignment_axis
-    {
-        cross_axis = match alignment {
-            Alignment::Start => alignment_axis,
-            Alignment::End => -alignment_axis,
-        };
+    if let Some(alignment) = alignment {
+        if let Some(alignment_axis) = alignment_axis {
+            cross_axis = match alignment {
+                Alignment::Start => alignment_axis,
+                Alignment::End => -alignment_axis,
+            };
+        }
     }
 
     if is_vertical {
@@ -192,20 +192,20 @@ impl<Element: Clone + PartialEq, Window: Clone + PartialEq> Middleware<Element, 
         let diff_coords = convert_value_to_coords(state, &options);
 
         // If the placement is the same and the arrow caused an alignment offset then we don't need to change the positioning coordinates.
-        if let Some(data_placement) = data.map(|data| data.placement)
-            && placement == data_placement
-        {
-            let arrow_data: Option<ArrowData> = middleware_data.get_as(ARROW_NAME);
-            if arrow_data
-                .and_then(|arrow_data| arrow_data.alignment_offset)
-                .is_some()
-            {
-                return MiddlewareReturn {
-                    x: None,
-                    y: None,
-                    data: None,
-                    reset: None,
-                };
+        if let Some(data_placement) = data.map(|data| data.placement) {
+            if placement == data_placement {
+                let arrow_data: Option<ArrowData> = middleware_data.get_as(ARROW_NAME);
+                if arrow_data
+                    .and_then(|arrow_data| arrow_data.alignment_offset)
+                    .is_some()
+                {
+                    return MiddlewareReturn {
+                        x: None,
+                        y: None,
+                        data: None,
+                        reset: None,
+                    };
+                }
             }
         }
 

--- a/packages/core/src/types.rs
+++ b/packages/core/src/types.rs
@@ -277,7 +277,7 @@ pub trait Middleware<Element: Clone + 'static, Window: Clone + 'static>: Clone +
 /// Middleware with options.
 pub trait MiddlewareWithOptions<Element: Clone, Window: Clone, O: Clone> {
     /// The options passed to this middleware.
-    fn options(&self) -> &Derivable<Element, Window, O>;
+    fn options(&self) -> &Derivable<'_, Element, Window, O>;
 }
 
 pub struct Elements<'a, Element: Clone + 'static> {

--- a/packages/dioxus/src/use_floating.rs
+++ b/packages/dioxus/src/use_floating.rs
@@ -65,28 +65,29 @@ pub fn use_floating(
     });
 
     let update = use_callback(move |_| {
-        if let Some(reference_element) = reference().map(|reference| reference.as_web_event())
-            && let Some(floating_element) = floating().map(|floating| floating.as_web_event())
-        {
-            let config = ComputePositionConfig {
-                placement: Some(placement_option()),
-                strategy: Some(strategy_option()),
-                middleware: Some(middleware_option()),
-            };
+        if let Some(reference_element) = reference().map(|reference| reference.as_web_event()) {
+            if let Some(floating_element) = floating().map(|floating| floating.as_web_event()) {
+                let config = ComputePositionConfig {
+                    placement: Some(placement_option()),
+                    strategy: Some(strategy_option()),
+                    middleware: Some(middleware_option()),
+                };
 
-            let open = open_option();
+                let open = open_option();
 
-            let position = compute_position((&reference_element).into(), &floating_element, config);
-            x.set(position.x);
-            y.set(position.y);
-            strategy.set(position.strategy);
-            placement.set(position.placement);
-            middleware_data.set(position.middleware_data);
-            // The floating element's position may be recomputed while it's closed
-            // but still mounted (such as when transitioning out). To ensure
-            // `is_positioned` will be `false` initially on the next open,
-            // avoid setting it to `true` when `open === false` (must be specified).
-            is_positioned.set(open);
+                let position =
+                    compute_position((&reference_element).into(), &floating_element, config);
+                x.set(position.x);
+                y.set(position.y);
+                strategy.set(position.strategy);
+                placement.set(position.placement);
+                middleware_data.set(position.middleware_data);
+                // The floating element's position may be recomputed while it's closed
+                // but still mounted (such as when transitioning out). To ensure
+                // `is_positioned` will be `false` initially on the next open,
+                // avoid setting it to `true` when `open === false` (must be specified).
+                is_positioned.set(open);
+            }
         }
     });
 
@@ -108,16 +109,18 @@ pub fn use_floating(
         cleanup.call(());
 
         if let Some(while_elements_mounted) = &while_elements_mounted_option {
-            if let Some(reference_element) = reference().map(|reference| reference.as_web_event())
-                && let Some(floating_element) = floating().map(|floating| floating.as_web_event())
-            {
-                while_elements_mounted_cleanup.replace(Some(Rc::new((*while_elements_mounted)(
-                    (&reference_element).into(),
-                    &floating_element,
-                    Rc::new(move || {
-                        update.call(());
-                    }),
-                ))));
+            if let Some(reference_element) = reference().map(|reference| reference.as_web_event()) {
+                if let Some(floating_element) = floating().map(|floating| floating.as_web_event()) {
+                    while_elements_mounted_cleanup.replace(Some(Rc::new(
+                        (*while_elements_mounted)(
+                            (&reference_element).into(),
+                            &floating_element,
+                            Rc::new(move || {
+                                update.call(());
+                            }),
+                        ),
+                    )));
+                }
             }
         } else {
             update.call(());

--- a/packages/dom/src/auto_update.rs
+++ b/packages/dom/src/auto_update.rs
@@ -346,17 +346,18 @@ pub fn auto_update(
             let update = update.clone();
 
             move |entries: Vec<ResizeObserverEntry>| {
-                if let Some(first_entry) = entries.first()
-                    && resize_reference_element
+                if let Some(first_entry) = entries.first() {
+                    if resize_reference_element
                         .as_ref()
                         .is_some_and(|reference_element| first_entry.target() == *reference_element)
-                {
-                    if let Some(reobserve_frame) = reobserve_frame.take() {
-                        cancel_animation_frame(reobserve_frame);
-                    }
+                    {
+                        if let Some(reobserve_frame) = reobserve_frame.take() {
+                            cancel_animation_frame(reobserve_frame);
+                        }
 
-                    reobserve_frame
-                        .replace(Some(request_animation_frame(reobserve_closure.as_ref())));
+                        reobserve_frame
+                            .replace(Some(request_animation_frame(reobserve_closure.as_ref())));
+                    }
                 }
 
                 update();
@@ -368,14 +369,14 @@ pub fn auto_update(
                 .expect("Resize observer should be created."),
         ));
 
-        if let Some(reference) = reference_element.as_ref()
-            && !animation_frame
-        {
-            resize_observer
-                .borrow()
-                .as_ref()
-                .expect("Resize observer should exist.")
-                .observe(reference);
+        if let Some(reference) = reference_element.as_ref() {
+            if !animation_frame {
+                resize_observer
+                    .borrow()
+                    .as_ref()
+                    .expect("Resize observer should exist.")
+                    .observe(reference);
+            }
         }
 
         resize_observer
@@ -405,10 +406,10 @@ pub fn auto_update(
             let next_ref_rect =
                 get_bounding_client_rect((&owned_reference).into(), false, false, None);
 
-            if let Some(prev_ref_rect) = prev_ref_rect.borrow().as_ref()
-                && !rects_are_equal(prev_ref_rect, &next_ref_rect)
-            {
-                update();
+            if let Some(prev_ref_rect) = prev_ref_rect.borrow().as_ref() {
+                if !rects_are_equal(prev_ref_rect, &next_ref_rect) {
+                    update();
+                }
             }
 
             prev_ref_rect.replace(Some(next_ref_rect));
@@ -426,13 +427,14 @@ pub fn auto_update(
 
         let next_ref_rect = get_bounding_client_rect((&owned_reference).into(), false, false, None);
 
-        if let Some(prev_ref_rect) = prev_ref_rect.borrow().as_ref()
-            && (next_ref_rect.x != prev_ref_rect.x
+        if let Some(prev_ref_rect) = prev_ref_rect.borrow().as_ref() {
+            if next_ref_rect.x != prev_ref_rect.x
                 || next_ref_rect.y != prev_ref_rect.y
                 || next_ref_rect.width != prev_ref_rect.width
-                || next_ref_rect.height != prev_ref_rect.height)
-        {
-            update();
+                || next_ref_rect.height != prev_ref_rect.height
+            {
+                update();
+            }
         }
 
         prev_ref_rect.replace(Some(next_ref_rect));

--- a/packages/dom/src/platform/convert_offset_parent_relative_rect_to_viewport_relative_rect.rs
+++ b/packages/dom/src/platform/convert_offset_parent_relative_rect_to_viewport_relative_rect.rs
@@ -53,11 +53,12 @@ pub fn convert_offset_parent_relative_rect_to_viewport_relative_rect(
 
     #[allow(clippy::nonminimal_bool)]
     if is_offset_parent_an_element || (!is_offset_parent_an_element && !is_fixed) {
-        if let Some(offset_parent) = offset_parent.as_ref()
-            && (get_node_name(offset_parent.into()) != "body"
-                || is_overflow_element(&document_element))
-        {
-            scroll = get_node_scroll(offset_parent.into());
+        if let Some(offset_parent) = offset_parent.as_ref() {
+            if get_node_name(offset_parent.into()) != "body"
+                || is_overflow_element(&document_element)
+            {
+                scroll = get_node_scroll(offset_parent.into());
+            }
         }
 
         if let Some(ElementOrWindow::Element(offset_parent)) = offset_parent {

--- a/packages/dom/src/platform/get_offset_parent.rs
+++ b/packages/dom/src/platform/get_offset_parent.rs
@@ -29,18 +29,19 @@ pub fn get_true_offset_parent(element: &Element, polyfill: &Option<Polyfill>) ->
 
             // Firefox returns the <html> element as the offsetParent if it's non-static, while Chrome and Safari return the <body> element.
             // The <body> element must be used to perform the correct calculations even if the <html> element is non-static.
-            if let Some(raw_offset_parent) = raw_offset_parent.as_ref()
-                && get_document_element(Some(DomNodeOrWindow::Node(raw_offset_parent)))
+            if let Some(raw_offset_parent) = raw_offset_parent.as_ref() {
+                if get_document_element(Some(DomNodeOrWindow::Node(raw_offset_parent)))
                     == *raw_offset_parent
-            {
-                return Some(
-                    raw_offset_parent
-                        .owner_document()
-                        .expect("Element should have owner document.")
-                        .body()
-                        .expect("Document should have body.")
-                        .unchecked_into::<Element>(),
-                );
+                {
+                    return Some(
+                        raw_offset_parent
+                            .owner_document()
+                            .expect("Element should have owner document.")
+                            .body()
+                            .expect("Document should have body.")
+                            .unchecked_into::<Element>(),
+                    );
+                }
             }
 
             raw_offset_parent
@@ -87,12 +88,13 @@ pub fn get_offset_parent(
         }
     }
 
-    if let Some(parent) = offset_parent.as_ref()
-        && is_last_traversable_node(parent)
-        && is_static_positioned(parent)
-        && !is_containing_block(parent.into())
-    {
-        return OwnedElementOrWindow::Window(window);
+    if let Some(parent) = offset_parent.as_ref() {
+        if is_last_traversable_node(parent)
+            && is_static_positioned(parent)
+            && !is_containing_block(parent.into())
+        {
+            return OwnedElementOrWindow::Window(window);
+        }
     }
 
     offset_parent

--- a/packages/leptos/src/use_floating.rs
+++ b/packages/leptos/src/use_floating.rs
@@ -214,33 +214,38 @@ pub fn use_floating<R: Into<Reference>>(
 
     let update = Rc::new({
         move || {
-            if let Some(reference) = reference.get_untracked()
-                && let Some(reference_element) = reference.get_untracked()
-                && let Some(floating_element) = floating
-                    .get_untracked()
-                    .and_then(|floating| floating.dyn_into::<web_sys::Element>().ok())
-            {
-                let config = ComputePositionConfig {
-                    placement: Some(placement_option_untracked()),
-                    strategy: Some(strategy_option_untracked()),
-                    middleware: middleware_option_untracked()
-                        .map(|middleware| middleware.deref().clone()),
-                };
+            if let Some(reference) = reference.get_untracked() {
+                if let Some(reference_element) = reference.get_untracked() {
+                    if let Some(floating_element) = floating
+                        .get_untracked()
+                        .and_then(|floating| floating.dyn_into::<web_sys::Element>().ok())
+                    {
+                        let config = ComputePositionConfig {
+                            placement: Some(placement_option_untracked()),
+                            strategy: Some(strategy_option_untracked()),
+                            middleware: middleware_option_untracked()
+                                .map(|middleware| middleware.deref().clone()),
+                        };
 
-                let open = open_option.get_untracked();
+                        let open = open_option.get_untracked();
 
-                let position =
-                    compute_position((&reference_element).into(), &floating_element, config);
-                set_x.set(position.x);
-                set_y.set(position.y);
-                set_strategy.set(position.strategy);
-                set_placement.set(position.placement);
-                set_middleware_data.set(position.middleware_data);
-                // The floating element's position may be recomputed while it's closed
-                // but still mounted (such as when transitioning out). To ensure
-                // `is_positioned` will be `false` initially on the next open,
-                // avoid setting it to `true` when `open === false` (must be specified).
-                set_is_positioned.set(open);
+                        let position = compute_position(
+                            (&reference_element).into(),
+                            &floating_element,
+                            config,
+                        );
+                        set_x.set(position.x);
+                        set_y.set(position.y);
+                        set_strategy.set(position.strategy);
+                        set_placement.set(position.placement);
+                        set_middleware_data.set(position.middleware_data);
+                        // The floating element's position may be recomputed while it's closed
+                        // but still mounted (such as when transitioning out). To ensure
+                        // `is_positioned` will be `false` initially on the next open,
+                        // avoid setting it to `true` when `open === false` (must be specified).
+                        set_is_positioned.set(open);
+                    }
+                }
             }
         }
     });
@@ -273,20 +278,22 @@ pub fn use_floating<R: Into<Reference>>(
 
             match while_elements_mounted_untracked() {
                 Some(while_elements_mounted) => {
-                    if let Some(reference) = reference.get_untracked()
-                        && let Some(reference_element) = reference.get_untracked()
-                        && let Some(floating_element) = floating
-                            .get_untracked()
-                            .and_then(|floating| floating.dyn_into::<web_sys::Element>().ok())
-                    {
-                        *while_elements_mounted_cleanup
-                            .lock()
-                            .expect("Lock should be acquired.") =
-                            Some(SendWrapper::new(while_elements_mounted(
-                                (&reference_element).into(),
-                                &floating_element,
-                                update.clone(),
-                            )));
+                    if let Some(reference) = reference.get_untracked() {
+                        if let Some(reference_element) = reference.get_untracked() {
+                            if let Some(floating_element) = floating
+                                .get_untracked()
+                                .and_then(|floating| floating.dyn_into::<web_sys::Element>().ok())
+                            {
+                                *while_elements_mounted_cleanup
+                                    .lock()
+                                    .expect("Lock should be acquired.") =
+                                    Some(SendWrapper::new(while_elements_mounted(
+                                        (&reference_element).into(),
+                                        &floating_element,
+                                        update.clone(),
+                                    )));
+                            }
+                        }
                     }
                 }
                 _ => {

--- a/packages/leptos/tests/visual/src/spec/auto_update.rs
+++ b/packages/leptos/tests/visual/src/spec/auto_update.rs
@@ -62,43 +62,43 @@ pub fn AutoUpdate() -> impl IntoView {
         let update = update.clone();
 
         move |_| {
-            if let Some(reference) = reference_ref.get()
-                && let Some(floating) = floating_ref.get()
-            {
-                if let Some(cleanup) = &*cleanup.read_value() {
-                    cleanup();
+            if let Some(reference) = reference_ref.get() {
+                if let Some(floating) = floating_ref.get() {
+                    if let Some(cleanup) = &*cleanup.read_value() {
+                        cleanup();
+                    }
+
+                    let size_factor = match layout_shift.get() {
+                        LayoutShift::Move => 0.9,
+                        _ => 1.0,
+                    };
+
+                    // Match React test behaviour by moving the size change from style attributes to here.
+                    // The style attributes update after this effect, so `auto_update` would not use the correct size.
+                    let style = reference.unchecked_ref::<web_sys::HtmlElement>().style();
+
+                    style
+                        .set_property(
+                            "width",
+                            &format!("{}px", reference_size.get() as f64 * size_factor),
+                        )
+                        .expect("Style should be updated.");
+                    style
+                        .set_property(
+                            "height",
+                            &format!("{}px", reference_size.get() as f64 * size_factor),
+                        )
+                        .expect("Style should be updated.");
+
+                    cleanup.set_value(Some(SendWrapper::new(auto_update(
+                        (&reference).into(),
+                        &floating,
+                        (*update).clone(),
+                        options
+                            .get()
+                            .layout_shift(layout_shift.get() != LayoutShift::None),
+                    ))));
                 }
-
-                let size_factor = match layout_shift.get() {
-                    LayoutShift::Move => 0.9,
-                    _ => 1.0,
-                };
-
-                // Match React test behaviour by moving the size change from style attributes to here.
-                // The style attributes update after this effect, so `auto_update` would not use the correct size.
-                let style = reference.unchecked_ref::<web_sys::HtmlElement>().style();
-
-                style
-                    .set_property(
-                        "width",
-                        &format!("{}px", reference_size.get() as f64 * size_factor),
-                    )
-                    .expect("Style should be updated.");
-                style
-                    .set_property(
-                        "height",
-                        &format!("{}px", reference_size.get() as f64 * size_factor),
-                    )
-                    .expect("Style should be updated.");
-
-                cleanup.set_value(Some(SendWrapper::new(auto_update(
-                    (&reference).into(),
-                    &floating,
-                    (*update).clone(),
-                    options
-                        .get()
-                        .layout_shift(layout_shift.get() != LayoutShift::None),
-                ))));
             }
         }
     });

--- a/packages/leptos/tests/visual/src/spec/inline.rs
+++ b/packages/leptos/tests/visual/src/spec/inline.rs
@@ -84,10 +84,10 @@ pub fn Inline() -> impl IntoView {
     let handle_mouse_up = move |event: MouseEvent| {
         let target: web_sys::Node = event_target(&event);
 
-        if let Some(floating) = floating_ref.get()
-            && floating.contains(Some(&target))
-        {
-            return;
+        if let Some(floating) = floating_ref.get() {
+            if floating.contains(Some(&target)) {
+                return;
+            }
         }
 
         set_timeout(
@@ -137,10 +137,10 @@ pub fn Inline() -> impl IntoView {
     let handle_mouse_down = move |event: MouseEvent| {
         let target: web_sys::Node = event_target(&event);
 
-        if let Some(floating) = floating_ref.get()
-            && floating.contains(Some(&target))
-        {
-            return;
+        if let Some(floating) = floating_ref.get() {
+            if floating.contains(Some(&target)) {
+                return;
+            }
         }
 
         if window()

--- a/packages/utils/src/dom.rs
+++ b/packages/utils/src/dom.rs
@@ -391,10 +391,10 @@ pub fn get_overflow_ancestors(
             list.push(OverflowAncestor::Element(scrollable_ancestor.into()));
         }
 
-        if let Some(frame_element) = frame_element
-            && traverse_iframe
-        {
-            list.append(&mut get_overflow_ancestors(&frame_element, vec![], true))
+        if let Some(frame_element) = frame_element {
+            if traverse_iframe {
+                list.append(&mut get_overflow_ancestors(&frame_element, vec![], true))
+            }
         }
 
         list

--- a/packages/yew/src/use_floating.rs
+++ b/packages/yew/src/use_floating.rs
@@ -148,34 +148,34 @@ pub fn use_floating(
                 middleware_data,
                 is_positioned,
             )| {
-                if let Some(reference_element) = reference.get()
-                    && let Some(floating_element) = floating.get()
-                {
-                    let config = ComputePositionConfig {
-                        placement: Some(**placement_option),
-                        strategy: Some(**strategy_option),
-                        middleware: Some((**middleware_option).clone()),
-                    };
+                if let Some(reference_element) = reference.get() {
+                    if let Some(floating_element) = floating.get() {
+                        let config = ComputePositionConfig {
+                            placement: Some(**placement_option),
+                            strategy: Some(**strategy_option),
+                            middleware: Some((**middleware_option).clone()),
+                        };
 
-                    let open = *open_option;
+                        let open = *open_option;
 
-                    let position = compute_position(
-                        (&reference_element).into(),
-                        floating_element
-                            .dyn_ref()
-                            .expect("Floating element should be an Element."),
-                        config,
-                    );
-                    x.set(position.x);
-                    y.set(position.y);
-                    strategy.set(position.strategy);
-                    placement.set(position.placement);
-                    middleware_data.set(position.middleware_data);
-                    // The floating element's position may be recomputed while it's closed
-                    // but still mounted (such as when transitioning out). To ensure
-                    // `is_positioned` will be `false` initially on the next open,
-                    // avoid setting it to `true` when `open === false` (must be specified).
-                    is_positioned.set(open);
+                        let position = compute_position(
+                            (&reference_element).into(),
+                            floating_element
+                                .dyn_ref()
+                                .expect("Floating element should be an Element."),
+                            config,
+                        );
+                        x.set(position.x);
+                        y.set(position.y);
+                        strategy.set(position.strategy);
+                        placement.set(position.placement);
+                        middleware_data.set(position.middleware_data);
+                        // The floating element's position may be recomputed while it's closed
+                        // but still mounted (such as when transitioning out). To ensure
+                        // `is_positioned` will be `false` initially on the next open,
+                        // avoid setting it to `true` when `open === false` (must be specified).
+                        is_positioned.set(open);
+                    }
                 }
             }
         },
@@ -215,24 +215,24 @@ pub fn use_floating(
                 cleanup.emit(());
 
                 if let Some(while_elements_mounted) = while_elements_mounted_option {
-                    if let Some(reference_element) = reference.get()
-                        && let Some(floating_element) = floating.get()
-                    {
-                        while_elements_mounted_cleanup.replace(Some(ShallowRc::from(
-                            (**while_elements_mounted)(
-                                (&reference_element).into(),
-                                floating_element
-                                    .dyn_ref()
-                                    .expect("Floating element should be an Element."),
-                                Rc::new({
-                                    let update = update.clone();
+                    if let Some(reference_element) = reference.get() {
+                        if let Some(floating_element) = floating.get() {
+                            while_elements_mounted_cleanup.replace(Some(ShallowRc::from(
+                                (**while_elements_mounted)(
+                                    (&reference_element).into(),
+                                    floating_element
+                                        .dyn_ref()
+                                        .expect("Floating element should be an Element."),
+                                    Rc::new({
+                                        let update = update.clone();
 
-                                    move || {
-                                        update.emit(());
-                                    }
-                                }),
-                            ),
-                        )));
+                                        move || {
+                                            update.emit(());
+                                        }
+                                    }),
+                                ),
+                            )));
+                        }
                     }
                 } else {
                     update.emit(());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/scripts/src/bin/upstream.rs
+++ b/scripts/src/bin/upstream.rs
@@ -1,5 +1,3 @@
-#![feature(exit_status_error)]
-
 use std::{
     collections::{BTreeMap, HashMap},
     env,
@@ -13,7 +11,7 @@ use octocrab::{
     models::repos::{CommitAuthor, Release},
     params::repos::Reference,
 };
-use scripts::ref_sha;
+use scripts::{ExitStatusExt, ref_sha};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, VariantArray};
@@ -210,7 +208,7 @@ async fn create_pull_request(
         .arg("https://github.com/floating-ui/floating-ui.git")
         .arg(temp_dir.path().to_str().expect("Path is valid UTF-8."))
         .status()?
-        .exit_ok()?;
+        .stable_exit_ok()?;
 
     log::debug!("git diff {current_tag}..{new_tag} -- {directory}");
     let output = Command::new("git")

--- a/scripts/src/lib.rs
+++ b/scripts/src/lib.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, fmt, num::NonZeroI32, process::ExitStatus};
 
 use octocrab::models::repos::Ref;
 
@@ -7,5 +7,36 @@ pub fn ref_sha(reference: Ref) -> Result<String, Box<dyn Error>> {
         octocrab::models::repos::Object::Commit { sha, .. } => Ok(sha),
         octocrab::models::repos::Object::Tag { sha, .. } => Ok(sha),
         _ => Err("Unknown reference object.".into()),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExitStatusError(Option<NonZeroI32>);
+
+impl fmt::Display for ExitStatusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(code) = self.0 {
+            write!(f, "process exited unsuccessfully: {code}")
+        } else {
+            write!(f, "process exited unsuccessfully: unknown")
+        }
+    }
+}
+
+impl Error for ExitStatusError {}
+
+pub trait ExitStatusExt {
+    fn stable_exit_ok(&self) -> Result<(), ExitStatusError>;
+}
+
+impl ExitStatusExt for ExitStatus {
+    fn stable_exit_ok(&self) -> Result<(), ExitStatusError> {
+        match self.code() {
+            Some(code) => match NonZeroI32::try_from(code) {
+                Ok(code) => Err(ExitStatusError(Some(code))),
+                Err(_) => Ok(()),
+            },
+            None => Err(ExitStatusError(None)),
+        }
     }
 }


### PR DESCRIPTION
Closes #154.

Unfortunately, the use of the nightly toolchain caused this library to be incompatible with stable Rust. The nightly toolchain was only used for `exit_ok` in a script, but this can easily be polyfilled.