### PR TITLE
fix(dom): break frame-loop closure Rc cycle in auto_update cleanup

### DIFF
--- a/packages/dom/src/auto_update.rs
+++ b/packages/dom/src/auto_update.rs
@@ -401,6 +401,7 @@ pub fn auto_update(
     let frame_loop_frame_id = frame_id.clone();
     let frame_loop_closure = Rc::new(RefCell::new(None));
     let frame_loop_closure_clone = frame_loop_closure.clone();
+    let frame_loop_closure_cleanup = frame_loop_closure.clone();
 
     *frame_loop_closure_clone.borrow_mut() = Some(Closure::new({
         let owned_reference = owned_reference.clone();
@@ -495,5 +496,7 @@ pub fn auto_update(
         if let Some(frame_id) = frame_id.take() {
             cancel_animation_frame(frame_id);
         }
+
+        drop(frame_loop_closure_cleanup.borrow_mut().take());
     })
 }


### PR DESCRIPTION
## Summary

Fixes #349.

`auto_update` builds a self-rescheduling animation-frame closure that is stored
in an `Rc<RefCell<Option<Closure>>>` and captures a clone of that same `Rc` so
it can reschedule itself, forming a strong reference cycle. The cleanup returned
by `auto_update` only cancelled the pending animation frame and never cleared
the cell, so the cycle was never broken — every call leaked the closure together
with the reference element clone and the `update` callback it captures. The
closure is built unconditionally, so the leak happened in both `animation_frame`
modes.

## Fix

Keep a separate handle to the cell and drop its contents in the returned
cleanup, **after** the animation frame is cancelled (so the closure can no
longer run before it is dropped). This breaks the cycle and lets the closure and
everything it captures be freed.

## Safety

The pending frame is cancelled before the closure is dropped, so there is no
use-after-free in wasm, and external cleanup never runs concurrently with a RAF
tick.

## Verification

- `cargo check -p floating-ui-dom --target wasm32-unknown-unknown` compiles.
- `cargo clippy -p floating-ui-dom` reports no new warnings.

## Note

A sibling instance of the same self-referential-`Rc`-closure pattern exists in
`observe_move`'s `refresh_closure` (see the "Possibly related" section of #349).
It is trickier because its cleanup is also invoked from inside the refresh
closure, so it is intentionally left out of this PR and can be addressed
separately.
